### PR TITLE
align answer fields with 'give feedback...'

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@ body#page-question-type-varnumunit div[id^=fitem_id_][id*=otherunitlabel] + .fit
     border-bottom: 0;
 }
 /* Bottom */
-body#page-question-type-varnumunit div[id^=fitem_id_][id*=syserrorpenalty_],
+body#page-question-type-varnumunit div[id^=fgroup_id_][id*=autofirerow3_],
 body#page-question-type-varnumunit div[id^=fitem_id_][id*=unitsfeedback_],
 body#page-question-type-varnumunit div[id^=fitem_id_][id*=id_otherunitfeedback] {
     background: #EEE;
@@ -89,12 +89,15 @@ body#page-question-type-varnumunit #fitem_id_addunits {
 body#page-question-type-varnumunit #fitem_id_answer_0 {
     margin-top: 1em;
 }
-body#page-question-type-varnumunit div[id^=fgroup_id_][id*=answeroptions_] label[for^='id_answer_'],
-body#page-question-type-varnumunit div[id^=fgroup_id_][id*=autofirerow1_] label[for^='id_checknumerical_'],
-body#page-question-type-varnumunit div[id^=fgroup_id_][id*=autofirerow2_] label[for^='id_checkpowerof10_'] {
+body#page-question-type-varnumunit div[id^=fgroup_id_][id*=answeroptions_] label[for^='id_answer_'] {
     position: absolute;
     left: -10000px;
     font-weight: normal;
     font-size: 1em;
+}
+body#page-question-type-varnumunit div[id^=fgroup_id_][id*=autofirerow1_] label[for^='id_checknumerical_'],
+body#page-question-type-varnumunit div[id^=fgroup_id_][id*=autofirerow2_] label[for^='id_checkpowerof10_'],
+body#page-question-type-varnumunit div[id^=fgroup_id_][id*=autofirerow3_] label[for^='id_syserrorpenalty_'] {
+    margin-left: 0; 
 }
 


### PR DESCRIPTION
Phil asked

Within each Answer box I would suggest that the bottom three lines should be indented to line up under "Give feedback...".

This commit addresses this request. Leaving separate from main bug in case a different fix is required. Specifically had to group the field 'syserrorpenalty' into a new group 'autofirerow3' to align the labels properly. This may not be the best solution.
