### PR TITLE
11 Fix Unknown format passed to format_text: html

### DIFF
--- a/tests/helper.php
+++ b/tests/helper.php
@@ -54,7 +54,7 @@ class qtype_varnumunit_test_helper extends question_test_helper {
                                                  '12345', // Answer.
                                                  '1',     // Fraction.
                                                  '<p>Your answer is correct.</p>', // Feedback.
-                                                 'html',  // Feedbackformat.
+                                                 FORMAT_HTML, // Feedbackformat.
                                                  '3',     // Sigfigs.
                                                  '',      // Error.
                                                  '0.1',   // Syserrorpenalty.
@@ -68,7 +68,7 @@ class qtype_varnumunit_test_helper extends question_test_helper {
                                                  '*',     // Answer.
                                                  '0',     // Fraction.
                                                  '<p>Your answer is incorrect.</p>', // Feedback.
-                                                 'html',  // Feedbackformat.
+                                                 FORMAT_HTML, // Feedbackformat.
                                                  '0',     // Sigfigs.
                                                  '',      // Error.
                                                  '0.1000000', // Syserrorpenalty.
@@ -125,7 +125,7 @@ class qtype_varnumunit_test_helper extends question_test_helper {
                                 '4000',  // Answer.
                                 '1',     // Fraction.
                                 '<p>Your answer is correct.</p>', // Feedback.
-                                'html',  // Feedbackformat.
+                                FORMAT_HTML, // Feedbackformat.
                                 '4',     // Sigfigs.
                                 '',      // Error.
                                 '0.1000000', // Syserrorpenalty.
@@ -139,7 +139,7 @@ class qtype_varnumunit_test_helper extends question_test_helper {
                                  '*',    // Answer.
                                  '0',    // Fraction.
                                  '<p>Your answer is incorrect.</p>', // Feedback.
-                                 'html', // Feedbackformat.
+                                 FORMAT_HTML, // Feedbackformat.
                                  '0',    // Sigfigs.
                                  '',     // Error.
                                  '0.1000000', // Syserrorpenalty.
@@ -206,7 +206,7 @@ class qtype_varnumunit_test_helper extends question_test_helper {
             '1',    // Answer.
             '1',    // Fraction.
             '<p>Your answer is correct.</p>', // Feedback.
-            'html', // Feedbackformat.
+            FORMAT_HTML, // Feedbackformat.
             '0',    // Sigfigs.
             '',     // Error.
             '0.1000000', // Syserrorpenalty.


### PR DESCRIPTION
The test helper previously used 'html' for the format passed to format_text().  This expects a FORMAT_ constant but prior to Moodle 4.4 defaulted to FORMAT_MOODLE for unrecognised values.  It now throws an exception for such values (MDL-80072).  This change uses FORMAT_HTML instead.

With this change all PHPUnit tests now pass (OK (30 tests, 416 assertions)).