### PR TITLE
12 Fix: Undefined array key "text"

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -118,7 +118,7 @@ class qtype_varnumunit extends qtype_varnumeric_base {
             if (html_is_blank($formdata->unitsfeedback[$i]['text'])) {
                 $formdata->unitsfeedback[$i]['text'] = '';
             }
-            if (html_is_blank($formdata->spacesfeedback[$i]['text'])) {
+            if (!array_key_exists('text', $formdata->spacesfeedback[$i]) || html_is_blank($formdata->spacesfeedback[$i]['text'])) {
                 $formdata->spacesfeedback[$i]['text'] = '';
             }
             $this->save_unit($table,


### PR DESCRIPTION
With Moodle 4.4 editor fields apparently don't include the 'text' field in the POSTed form data if there is no text.

PR for #12 